### PR TITLE
Reduce bundle size by replacing lodash with lodash.debounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "arraydiff": "^0.1.3",
     "gh-pages": "^1.1.0",
-    "lodash": "^4.17.4",
+    "lodash.debounce": "^4.0.8",
     "react": "^16.2.0",
     "react-copy": "^0.1.0",
     "react-dom": "^16.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import chain from './svg/chain.svg';
 import octocat from './svg/octocat.svg';
 
 import Copy from 'react-copy';
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import arrayDiff from 'arraydiff';
 
 class App extends Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,6 +3940,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"


### PR DESCRIPTION
Hi @hamsterbacke23,

what would be a better way of wishing you a happy new year than a nice pull request? 😉 

I've become a bit obsessed with the bundle size of my applications lately and by replacing the complete lodash library (which is a whopping 68.2kB, according to [bundlephobia](https://bundlephobia.com/result?p=lodash@4.17.4)) with lodash.debounce (which is 1.9 kB according to [bundlephobia](https://bundlephobia.com/result?p=lodash.debounce@4.0.8)) we can save 66.3 kB in bundle size. 😀 

lodash is not cool anyways, [ramda](https://github.com/ramda/ramda) is where it's at! 😉 

Btw I would love to hear from you!

Greetings from Stuttgart
kyusu
  